### PR TITLE
Add secret key docs for OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ python3 tesla_gui.py
 Nach dem Start werden die Fahrzeugdaten abgerufen und in übersichtlichen
 Abschnitten dargestellt. Über den Button „Aktualisieren" lassen sich die
 Werte jederzeit neu laden.
+
+## OAuth Login
+
+Für die Anmeldung per OAuth müssen bestimmte Umgebungsvariablen gesetzt sein.
+Um Flask-Sitzungen sicher zu signieren, wird insbesondere `FLASK_SECRET_KEY`
+benötigt.
+
+```bash
+export FLASK_SECRET_KEY=ein_geheimer_schlüssel
+```
+


### PR DESCRIPTION
## Summary
- document `FLASK_SECRET_KEY` environment variable in the README

## Testing
- `python3 -m py_compile tesla_web.py tesla_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6841ad8b449c8321a888a938a24e83f8