### PR TITLE
Add OAuth login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,19 @@ Grundinformationen eines Tesla-Fahrzeugs über die Tesla Owner API anzeigt.
 * Python 3
 * Flask (`pip install flask`)
 * Netzwerkzugriff auf die Tesla Owner API
-* Ein gültiges Tesla-API-Token, gespeichert in der Umgebungsvariable
-  `TESLA_TOKEN`
+* Entweder ein bereits erzeugtes Tesla-API-Token in der Umgebungsvariable
+  `TESLA_TOKEN` oder ein Login über den integrierten OAuth-Fluss
 
 ## Verwendung
 
-1. Einen Zugangstoken für dein Tesla-Konto erstellen.
-2. Die Umgebungsvariable `TESLA_TOKEN` setzen:
-
-```bash
-export TESLA_TOKEN=dein_token
-```
-
-3. Die Webanwendung starten:
+1. Die Webanwendung starten:
 
 ```bash
 python3 tesla_web.py
 ```
-
-4. Im Browser `http://localhost:8066/` öffnen (oder die entsprechende Adresse
-deines Servers), um den Fahrzeugstatus zu sehen.
+2. Im Browser `http://localhost:8066/` öffnen (oder die entsprechende Adresse
+deines Servers). Wenn kein Token in `TESLA_TOKEN` vorhanden ist, kannst du dich
+über `/login` per OAuth anmelden.
 
 Die Anwendung ruft dein erstes registriertes Fahrzeug ab und zeigt dessen
 Status, Innen- und Außentemperatur sowie den Batteriestand an. 
@@ -49,11 +42,17 @@ Werte jederzeit neu laden.
 
 ## OAuth Login
 
-Für die Anmeldung per OAuth müssen bestimmte Umgebungsvariablen gesetzt sein.
-Um Flask-Sitzungen sicher zu signieren, wird insbesondere `FLASK_SECRET_KEY`
-benötigt.
+Für die Anmeldung per OAuth muss Flask einen geheimen Schlüssel besitzen.
+Setze dafür die Variable `FLASK_SECRET_KEY`:
 
 ```bash
-export FLASK_SECRET_KEY=ein_geheimer_schlüssel
+export FLASK_SECRET_KEY=ein_geheimer_schluessel
 ```
+
+Danach kann die Anmeldung über `/login` gestartet werden. Tesla leitet nach
+dem Login auf `/oauth/callback` zurück und das erhaltene Access-Token wird in
+der Sitzung gespeichert.
+Optional lassen sich `TESLA_CLIENT_ID` und `TESLA_REDIRECT_URI` anpassen,
+standardmäßig wird jedoch der offizielle `ownerapi`-Client und
+`http://localhost:8066/oauth/callback` verwendet.
 

--- a/tesla_web.py
+++ b/tesla_web.py
@@ -1,9 +1,16 @@
 import json
 import os
-from urllib import request, error
-from flask import Flask, Response
+import base64
+import hashlib
+import secrets
+from urllib import request as urlrequest, error, parse
+from flask import Flask, Response, redirect, request, session, url_for
 
 API_BASE = "https://owner-api.teslamotors.com/api/1"
+AUTH_URL = "https://auth.tesla.com/oauth2/v3/authorize"
+TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"
+CLIENT_ID = os.getenv("TESLA_CLIENT_ID", "ownerapi")
+REDIRECT_URI = os.getenv("TESLA_REDIRECT_URI", "http://localhost:8066/oauth/callback")
 
 class TeslaClient:
     def __init__(self, token):
@@ -11,10 +18,10 @@ class TeslaClient:
 
     def _get(self, endpoint):
         url = f"{API_BASE}{endpoint}"
-        req = request.Request(url)
+        req = urlrequest.Request(url)
         req.add_header("Authorization", f"Bearer {self.token}")
         try:
-            with request.urlopen(req) as resp:
+            with urlrequest.urlopen(req) as resp:
                 return json.load(resp)
         except error.URLError as e:
             raise RuntimeError(f"API request failed: {e}")
@@ -28,12 +35,13 @@ class TeslaClient:
         return data.get("response", {})
 
 app = Flask(__name__)
+app.secret_key = os.getenv("FLASK_SECRET_KEY", os.urandom(16))
 
 @app.route('/')
 def index():
-    token = os.getenv('TESLA_TOKEN')
+    token = session.get('tesla_token') or os.getenv('TESLA_TOKEN')
     if not token:
-        return Response('Umgebungsvariable TESLA_TOKEN nicht gesetzt', status=500)
+        return redirect(url_for('login'))
 
     client = TeslaClient(token)
     try:
@@ -74,6 +82,56 @@ def index():
     </html>
     """
     return html
+
+
+@app.route("/login")
+def login():
+    code_verifier = base64.urlsafe_b64encode(os.urandom(64)).rstrip(b"=").decode("ascii")
+    session["code_verifier"] = code_verifier
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode("ascii")).digest()
+    ).rstrip(b"=").decode("ascii")
+    state = secrets.token_urlsafe(16)
+    session["state"] = state
+    params = parse.urlencode(
+        {
+            "client_id": CLIENT_ID,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": REDIRECT_URI,
+            "response_type": "code",
+            "scope": "openid email offline_access",
+            "state": state,
+        }
+    )
+    return redirect(f"{AUTH_URL}?{params}")
+
+
+@app.route("/oauth/callback")
+def oauth_callback():
+    if request.args.get("state") != session.get("state"):
+        return Response("Ungültiger State", status=400)
+    code = request.args.get("code")
+    if not code:
+        return Response("Fehlender Code", status=400)
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "code_verifier": session.get("code_verifier"),
+        "redirect_uri": REDIRECT_URI,
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urlrequest.Request(TOKEN_URL, data=data)
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urlrequest.urlopen(req) as resp:
+            token_data = json.load(resp)
+    except error.URLError as e:
+        return Response(f"Token-Anforderung fehlgeschlagen: {e}", status=500)
+    session["tesla_token"] = token_data.get("access_token")
+    session["refresh_token"] = token_data.get("refresh_token")
+    return redirect(url_for("index"))
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8066)


### PR DESCRIPTION
## Summary
- implement OAuth login and callback in `tesla_web.py`
- store tokens in Flask session
- document OAuth setup and new usage in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b40b71148321b33f5361a379bfc5